### PR TITLE
Listing repos requires admin user

### DIFF
--- a/src/main/java/com/dkaedv/glghproxy/controller/UsersController.java
+++ b/src/main/java/com/dkaedv/glghproxy/controller/UsersController.java
@@ -42,7 +42,7 @@ public class UsersController {
 		LOG.info("Received request: username=" + username + ", per_page=" + per_page + ", page=" + page);
 
 		GitlabAPI api = gitlab.connect(authorization);
-		List<GitlabProject> projects = api.getAllProjects();
+		List<GitlabProject> projects = api.getProjects();
 		
 		return GitlabToGithubConverter.convertRepositories(projects);
 	}


### PR DESCRIPTION
The `UsersController#getReposForUser` method calls the Gitlab API's `getAllProjects` method which requires an admin user to be connected.

For obvious reasons, I would like my jira user to not be a GitLab admin.

The following change uses the `api.getProjects()` method to list all projects **accessible** by the connected user.