### PR TITLE
Use un-synchronized Collections instead of Java2 Vector

### DIFF
--- a/src/main/java/com/dkaedv/glghproxy/controller/OrgsController.java
+++ b/src/main/java/com/dkaedv/glghproxy/controller/OrgsController.java
@@ -1,8 +1,8 @@
 package com.dkaedv.glghproxy.controller;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
-import java.util.Vector;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -29,6 +29,6 @@ public class OrgsController {
 		
 		LOG.info("Received request: orgname=" + orgname + ", per_page=" + per_page + ", page=" + page + ", authorization=" + authorization);
 
-		return new Vector<Repository>();
+		return Collections.emptyList();
 	}
 }

--- a/src/main/java/com/dkaedv/glghproxy/controller/ReposController.java
+++ b/src/main/java/com/dkaedv/glghproxy/controller/ReposController.java
@@ -1,8 +1,8 @@
 package com.dkaedv.glghproxy.controller;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
-import java.util.Vector;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -96,7 +96,7 @@ public class ReposController {
 			@RequestHeader("Authorization") String authorization
 			) {
 				
-		return new Vector<Event>();
+		return Collections.emptyList();
 	}
 
 	@RequestMapping("/{namespace}/{repo}/pulls")
@@ -180,7 +180,7 @@ public class ReposController {
 			@RequestHeader("Authorization") String authorization
 			) throws IOException {
 
-		return new Vector<Comment>();
+		return Collections.emptyList();
 	}
 
 	@RequestMapping(value = "/{namespace}/{repo}/hooks", method = RequestMethod.GET)

--- a/src/main/java/com/dkaedv/glghproxy/controller/UserController.java
+++ b/src/main/java/com/dkaedv/glghproxy/controller/UserController.java
@@ -1,8 +1,8 @@
 package com.dkaedv.glghproxy.controller;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
-import java.util.Vector;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -27,7 +27,7 @@ public class UserController {
 
 		LOG.info("Received request: per_page=" + per_page + ", page=" + page);
 
-		return new Vector<Repository>();
+		return Collections.emptyList();
 	}
 
 }

--- a/src/main/java/com/dkaedv/glghproxy/converter/GitlabToGithubConverter.java
+++ b/src/main/java/com/dkaedv/glghproxy/converter/GitlabToGithubConverter.java
@@ -1,8 +1,8 @@
 package com.dkaedv.glghproxy.converter;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Vector;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -49,7 +49,7 @@ public class GitlabToGithubConverter {
 	}
 
 	public static List<RepositoryBranch> convertBranches(List<GitlabBranch> glbranches) {
-		List<RepositoryBranch> branches = new Vector<RepositoryBranch>();
+		List<RepositoryBranch> branches = new ArrayList<>(glbranches.size());
 
 		for (GitlabBranch glbranch : glbranches) {
 			RepositoryBranch branch = convertBranch(glbranch);
@@ -81,9 +81,10 @@ public class GitlabToGithubConverter {
 		repoCommit.setAuthor(user);
 		repoCommit.setCommitter(user);
 
-		if (glcommit.getParentIds() != null) {
-			List<Commit> parents = new Vector<Commit>();
-			for (String parentSha : glcommit.getParentIds()) {
+		List<String> parentIds = glcommit.getParentIds();
+		if (parentIds != null) {
+			List<Commit> parents = new ArrayList<>(parentIds.size());
+			for (String parentSha : parentIds) {
 				Commit parent = new Commit();
 				parent.setSha(parentSha);
 				parents.add(parent);
@@ -92,7 +93,7 @@ public class GitlabToGithubConverter {
 		}
 		
 		if (gldiffs != null) {
-			List<CommitFile> files = new Vector<CommitFile>();
+			List<CommitFile> files = new ArrayList<>(gldiffs.size());
 			for (GitlabCommitDiff diff : gldiffs) {
 				convertCommitFile(files, diff);
 			}
@@ -159,7 +160,7 @@ public class GitlabToGithubConverter {
 	}
 
 	public static List<Repository> convertRepositories(List<GitlabProject> projects) {
-		List<Repository> repos = new Vector<Repository>();
+		List<Repository> repos = new ArrayList<>(projects.size());
 		
 		for (GitlabProject project : projects) {
 			repos.add(convertRepository(project));
@@ -169,7 +170,7 @@ public class GitlabToGithubConverter {
 	}
 
 	public static List<PullRequest> convertMergeRequests(List<GitlabMergeRequest> glmergerequests, String gitlabUrl, String namespace, String repo) {
-		List<PullRequest> pulls = new Vector<PullRequest>();
+		List<PullRequest> pulls = new ArrayList<>(glmergerequests.size());
 		
 		for (GitlabMergeRequest glmr : glmergerequests) {
 			pulls.add(convertMergeRequest(glmr, gitlabUrl, namespace, repo));
@@ -282,7 +283,7 @@ public class GitlabToGithubConverter {
 	}
 
 	public static List<RepositoryCommit> convertCommits(List<GitlabCommit> glcommits) {
-		List<RepositoryCommit> commits = new Vector<RepositoryCommit>();
+		List<RepositoryCommit> commits = new ArrayList<>(glcommits.size());
 		
 		for (GitlabCommit glcommit : glcommits) {
 			commits.add(convertCommit(glcommit, null, null));
@@ -292,7 +293,7 @@ public class GitlabToGithubConverter {
 	}
 
 	public static List<Comment> convertComments(List<GitlabNote> glnotes) {
-		List<Comment> comments = new Vector<Comment>();
+		List<Comment> comments = new ArrayList<>(glnotes.size());
 		
 		for (GitlabNote glnote : glnotes) {
 			comments.add(convertComment(glnote));
@@ -313,7 +314,7 @@ public class GitlabToGithubConverter {
 	}
 
 	public static List<RepositoryHook> convertHooks(List<GitlabProjectHook> glhooks) {
-		List<RepositoryHook> hooks = new Vector<RepositoryHook>();
+		List<RepositoryHook> hooks = new ArrayList<>(glhooks.size());
 		
 		for (GitlabProjectHook glhook : glhooks) {
 			hooks.add(convertHook(glhook));


### PR DESCRIPTION
The result objects returned by the proxy don't need to be synchronized.
However, the Vector class is fully synchronized for backwards compatibility (it's around since Java 2). This change uses the more lightweight ArrayList, initialized with the approximate target size, and the Collections.emptyList() singleton where applicable.

Since the project uses Java 7 anyway, I used diamond notation where possible.